### PR TITLE
fix Trait "Sushi\Sushi" not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "tomatophp/filament-developer-gate": "^1.0",
         "maatwebsite/excel": "^3.1",
         "creagia/filament-code-field": "^3.0",
-        "mallardduck/blade-boxicons": "^2.4"
+        "mallardduck/blade-boxicons": "^2.4",
+        "calebporzio/sushi": "^2.5"
     }
 }


### PR DESCRIPTION
After installing the package I get the error Trait "Sushi\Sushi" not found 
so I just added calebporzio/sushi package to composer.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management by adding a new package: `"calebporzio/sushi": "^2.5"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->