### PR TITLE
fix The GET method is not supported for route admin/developer-gate.

### DIFF
--- a/src/Pages/Browser.php
+++ b/src/Pages/Browser.php
@@ -55,15 +55,15 @@ class Browser extends Page implements HasTable
                     ->hidden(fn() => !filament('filament-browser')->allowCreateNewFile)
                     ->label(trans('filament-browser::messages.actions.create'))
                     ->icon('heroicon-o-plus')
-                    ->form(function (){
+                    ->form(function () {
                         $type = [
                             'file-code' => trans('filament-browser::messages.types.code'),
                             'file-markdown' => trans('filament-browser::messages.types.markdown'),
                         ];
-                        if(filament('filament-browser')->allowCreateFolder){
+                        if (filament('filament-browser')->allowCreateFolder) {
                             $type['folder'] = trans('filament-browser::messages.types.folder');
                         }
-                        if(filament('filament-browser')->allowUpload){
+                        if (filament('filament-browser')->allowUpload) {
                             $type['upload'] = trans('filament-browser::messages.types.upload');
                         }
                         return [
@@ -106,9 +106,9 @@ class Browser extends Page implements HasTable
                                     'md' => 'MD',
                                 ])
                                 ->live()
-                                ->afterStateUpdated(function (Get $get, Set $set){
+                                ->afterStateUpdated(function (Get $get, Set $set) {
                                     $this->language = $get('extension');
-                                    if($get('extension') === 'php'){
+                                    if ($get('extension') === 'php') {
                                         $set('code', '<?php');
                                     }
                                 })
@@ -133,19 +133,18 @@ class Browser extends Page implements HasTable
                                 ->hidden(fn(Get $get) => $get('type') != 'file-markdown'),
                         ];
                     })
-                    ->action(function (array $data){
-                        $path = session()->has('filament-browser-path') ? session()->get('filament-browser-path') : (filament('filament-browser')->basePath?: config('filament-browser.start_path'));
-                        if($data['type'] === 'upload'){
-                            $exists = File::exists($path . '/'.$data['file']);
-                            if($exists){
+                    ->action(function (array $data) {
+                        $path = session()->has('filament-browser-path') ? session()->get('filament-browser-path') : (filament('filament-browser')->basePath ?: config('filament-browser.start_path'));
+                        if ($data['type'] === 'upload') {
+                            $exists = File::exists($path . '/' . $data['file']);
+                            if ($exists) {
                                 Notification::make()
                                     ->title(trans('filament-browser::messages.notifications.file-exists'))
                                     ->danger()
                                     ->send();
-                                return ;
-                            }
-                            else {
-                                File::copy(storage_path('app/public/'. $data['file']), $path . '/'.$data['file']);
+                                return;
+                            } else {
+                                File::copy(storage_path('app/public/' . $data['file']), $path . '/' . $data['file']);
 
                                 Notification::make()
                                     ->title(trans('filament-browser::messages.notifications.uploaded'))
@@ -153,48 +152,48 @@ class Browser extends Page implements HasTable
                                     ->send();
                             }
 
-                            File::delete(storage_path('app/public/'. $data['file']));
-                        }elseif($data['type'] === 'file-code'){
-                            $exists = File::exists($path."/{$data['name']}.{$data['extension']}");
-                            if($exists){
+                            File::delete(storage_path('app/public/' . $data['file']));
+                        } elseif ($data['type'] === 'file-code') {
+                            $exists = File::exists($path . "/{$data['name']}.{$data['extension']}");
+                            if ($exists) {
                                 Notification::make()
                                     ->title(trans('filament-browser::messages.notifications.file-exists'))
                                     ->danger()
                                     ->send();
-                                return ;
+                                return;
                             }
-                            File::put($path."/{$data['name']}.{$data['extension']}", $data['code']);
+                            File::put($path . "/{$data['name']}.{$data['extension']}", $data['code']);
 
                             Notification::make()
                                 ->title(trans('filament-browser::messages.notifications.saved'))
                                 ->success()
                                 ->send();
-                        }elseif($data['type'] === 'file-markdown'){
-                            $exists = File::exists($path."/{$data['name']}.md");
-                            if($exists){
+                        } elseif ($data['type'] === 'file-markdown') {
+                            $exists = File::exists($path . "/{$data['name']}.md");
+                            if ($exists) {
                                 Notification::make()
                                     ->title(trans('filament-browser::messages.notifications.file-exists'))
                                     ->danger()
                                     ->send();
-                                return ;
+                                return;
                             }
-                            File::put($path."/{$data['name']}.md", $data['markdown']);
+                            File::put($path . "/{$data['name']}.md", $data['markdown']);
 
                             Notification::make()
                                 ->title(trans('filament-browser::messages.notifications.saved'))
                                 ->success()
                                 ->send();
-                        }elseif($data['type'] === 'folder'){
-                            $exists = File::exists($path."/{$data['name']}");
-                            if($exists){
+                        } elseif ($data['type'] === 'folder') {
+                            $exists = File::exists($path . "/{$data['name']}");
+                            if ($exists) {
                                 Notification::make()
                                     ->title(trans('filament-browser::messages.notifications.folder-exists'))
                                     ->danger()
                                     ->send();
-                                return ;
+                                return;
                             }
 
-                            File::makeDirectory($path."/{$data['name']}");
+                            File::makeDirectory($path . "/{$data['name']}");
 
                             Notification::make()
                                 ->title(trans('filament-browser::messages.notifications.created'))
@@ -208,7 +207,7 @@ class Browser extends Page implements HasTable
                     ->label(trans('filament-browser::messages.actions.home'))
                     ->icon('heroicon-o-home')
                     ->color('info')
-                    ->action(function (){
+                    ->action(function () {
                         session()->forget('filament-browser-path');
                         session()->forget('filament-browser-current');
 
@@ -219,16 +218,16 @@ class Browser extends Page implements HasTable
                     ->icon('heroicon-o-chevron-left')
                     ->color('warning')
                     ->hidden(fn() => !session()->has('filament-browser-current') || count(json_decode(session()->get('filament-browser-current'))) < 1)
-                    ->action(function (){
+                    ->action(function () {
                         $history = collect(json_decode(session()->get('filament-browser-current')))->last();
-                        $historyAfter = collect(json_decode(session()->get('filament-browser-current')))->filter(fn($item)=> $item != $history);
+                        $historyAfter = collect(json_decode(session()->get('filament-browser-current')))->filter(fn($item) => $item != $history);
                         session()->put('filament-browser-current', json_encode($historyAfter->toArray()));
                         session()->put('filament-browser-path', $historyAfter->last());
 
                         $this->dispatch('refreshTable');
                     }),
             ])
-            ->content(fn()=> view('filament-browser::table.content'))
+            ->content(fn() => view('filament-browser::table.content'))
             ->paginated(false)
             ->query(Files::query());
     }
@@ -237,7 +236,7 @@ class Browser extends Page implements HasTable
     {
         return [
             Action::make('developer_gate_logout')
-                ->action(function (){
+                ->action(function () {
                     session()->forget('developer_password');
 
                     Notification::make()
@@ -246,7 +245,7 @@ class Browser extends Page implements HasTable
                         ->success()
                         ->send();
 
-                    return redirect()->to('admin/developer-gate');
+                    return redirect()->to(config('filament-developer-gate.route_prefix') . '/developer-gate');
                 })
                 ->requiresConfirmation()
                 ->color('danger')
@@ -262,7 +261,7 @@ class Browser extends Page implements HasTable
     {
         return trans('filament-browser::messages.title');
     }
-    
+
     public static function getNavigationGroup(): ?string
     {
         return trans('filament-browser::messages.group');
@@ -273,10 +272,10 @@ class Browser extends Page implements HasTable
         return trans('filament-browser::messages.title');
     }
 
-    public function getFolderAction(?Files $file=null)
+    public function getFolderAction(?Files $file = null)
     {
         return Action::make('getFolderAction')
-            ->view('filament-browser::actions.folder', ['file'=> $file])
+            ->view('filament-browser::actions.folder', ['file' => $file])
             ->action(function (array $arguments) {
                 $currentArray = session()->has('filament-browser-current') ? json_decode(session()->get('filament-browser-current')) : [];
                 $currentArray[] = $arguments['file']['path'];
@@ -287,30 +286,15 @@ class Browser extends Page implements HasTable
             });
     }
 
-    public function getFileAction(?Files $file=null)
+    public function getFileAction(?Files $file = null)
     {
         return Action::make('getFileAction')
-            ->label(function (array $arguments){
+            ->label(function (array $arguments) {
                 return $arguments['file']['name'];
             })
-            ->fillForm(function (array $arguments){
+            ->fillForm(function (array $arguments) {
                 return [
                     'content' => (str($arguments['file']['extension'])->contains([
-                            "php",
-                            "json",
-                            "js",
-                            "yaml",
-                            "xml",
-                            "lock",
-                            "txt",
-                            "html",
-                            "log",
-                            "md",
-                        ]) || str($arguments['file']['name'])->contains(['.env', '.git', '.editor']) || empty($arguments['file']['extension'])) ? File::get($arguments['file']['path']): $arguments['file'],
-                ];
-            })
-            ->form(function (array $arguments){
-                return ((str($arguments['file']['extension'])->contains([
                         "php",
                         "json",
                         "js",
@@ -320,15 +304,30 @@ class Browser extends Page implements HasTable
                         "txt",
                         "html",
                         "log",
-                    ]) || str($arguments['file']['name'])->contains(['.env', '.git', '.editor']) || empty($arguments['file']['extension']) ) ?[
+                        "md",
+                    ]) || str($arguments['file']['name'])->contains(['.env', '.git', '.editor']) || empty($arguments['file']['extension'])) ? File::get($arguments['file']['path']) : $arguments['file'],
+                ];
+            })
+            ->form(function (array $arguments) {
+                return ((str($arguments['file']['extension'])->contains([
+                    "php",
+                    "json",
+                    "js",
+                    "yaml",
+                    "xml",
+                    "lock",
+                    "txt",
+                    "html",
+                    "log",
+                ]) || str($arguments['file']['name'])->contains(['.env', '.git', '.editor']) || empty($arguments['file']['extension'])) ? [
                     CodeField::make('content')
                         ->disabled(fn() => !filament('filament-browser')->allowEditFile)
                         ->label(trans('filament-browser::messages.edit.content'))
                         ->view('filament-browser::components.code')
                         ->setLanguage($arguments['file']['extension']),
-                ] : (str($arguments['file']['extension'])->contains('md') ? [MarkdownEditor::make('content')->label(trans('filament-browser::messages.edit.content'))->disabled(fn() => !filament('filament-browser')->allowEditFile)] :[]));
+                ] : (str($arguments['file']['extension'])->contains('md') ? [MarkdownEditor::make('content')->label(trans('filament-browser::messages.edit.content'))->disabled(fn() => !filament('filament-browser')->allowEditFile)] : []));
             })
-            ->extraModalFooterActions(function (array $arguments, Action $action){
+            ->extraModalFooterActions(function (array $arguments, Action $action) {
                 return [
                     Action::make('deleteFile')
                         ->hidden(fn() => !filament('filament-browser')->allowDeleteFile)
@@ -337,7 +336,7 @@ class Browser extends Page implements HasTable
                         ->icon('heroicon-o-trash')
                         ->requiresConfirmation()
                         ->cancelParentActions()
-                        ->action(function () use ($arguments, $action){
+                        ->action(function () use ($arguments, $action) {
                             File::delete($arguments['file']['path']);
 
                             Notification::make()
@@ -361,9 +360,9 @@ class Browser extends Page implements HasTable
                         ->fillForm([
                             "name" => $arguments['file']['name']
                         ])
-                        ->action(function (array $data) use ($arguments, $action){
+                        ->action(function (array $data) use ($arguments, $action) {
                             $exists = File::exists($arguments['file']['path']);
-                            if($exists){
+                            if ($exists) {
                                 File::move($arguments['file']['path'], str_replace($arguments['file']['name'], $data['name'], $arguments['file']['path']));
 
                                 Notification::make()
@@ -376,7 +375,7 @@ class Browser extends Page implements HasTable
                         }),
                 ];
             })
-            ->infolist(function (array $arguments){
+            ->infolist(function (array $arguments) {
                 File::deleteDirectory(storage_path('app/public/tmp'));
                 return filament('filament-browser')->allowPreview ? ((str($arguments['file']['extension'])->contains([
                     "php",
@@ -397,7 +396,7 @@ class Browser extends Page implements HasTable
                 ]) : [];
             })
             ->action(function (array $arguments, array $data) {
-                if(filament('filament-browser')->allowEditFile){
+                if (filament('filament-browser')->allowEditFile) {
                     (str($arguments['file']['extension'])->contains([
                         "php",
                         "json",
@@ -411,15 +410,14 @@ class Browser extends Page implements HasTable
                         "md",
                     ])) || str($arguments['file']['name'])->contains(['.env', '.git', '.editor']) || empty($arguments['file']['extension']) ? File::put($arguments['file']['path'], $data['content']) : null;
 
-                    if(isset($data) && isset($data['content'])){
+                    if (isset($data) && isset($data['content'])) {
                         Notification::make()
                             ->title(trans('filament-browser::messages.notifications.saved'))
                             ->success()
                             ->send();
                     }
                 }
-
             })
-            ->view('filament-browser::actions.file', ['file'=> $file]);
+            ->view('filament-browser::actions.file', ['file' => $file]);
     }
 }


### PR DESCRIPTION
I have I admin panel with / path but when logout I get The GET method is not supported for route admin/developer-gate. Supported methods: POST. because the prefix of my panel is not admin

and this is small fix for the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved code formatting and readability in the Browser module.
	- Adjusted logic for handling file uploads and notifications for clarity.
	- Streamlined content type determination for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->